### PR TITLE
Corrected presumably erroneus dependency in source.extension.vsixmani…

### DIFF
--- a/CocoPlugin/CocoPlugin.csproj
+++ b/CocoPlugin/CocoPlugin.csproj
@@ -13,7 +13,7 @@
     <AssemblyName>CocoPlugin</AssemblyName>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
@@ -74,14 +74,21 @@
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.VisualStudio.CommandBars, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.OLE.Interop">
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Package.LanguageService.14.0, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.Shell.14.0, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VisualStudio.Package.LanguageService.15.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VisualStudio.Shell.15.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop">
       <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.8.0">
       <Private>True</Private>
@@ -99,7 +106,7 @@
       <EmbedInteropTypes>False</EmbedInteropTypes>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.TextTemplating.VSHost.14.0, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VisualStudio.TextTemplating.VSHost.15.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
@@ -118,15 +125,6 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <COMReference Include="Microsoft.VisualStudio.CommandBars">
-      <Guid>{1CBA492E-7263-47BB-87FE-639000619B15}</Guid>
-      <VersionMajor>8</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>primary</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>False</EmbedInteropTypes>
-    </COMReference>
     <COMReference Include="stdole">
       <Guid>{00020430-0000-0000-C000-000000000046}</Guid>
       <VersionMajor>2</VersionMajor>

--- a/CocoPlugin/Resources.Designer.cs
+++ b/CocoPlugin/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace at.jku.ssw.Coco.VSPlugin {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/CocoPlugin/source.extension.vsixmanifest
+++ b/CocoPlugin/source.extension.vsixmanifest
@@ -1,28 +1,28 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Publisher="ssw.jku.at" Id="63c2b4b8-8a51-4fc4-b8ed-0b49e24146c3" Version="2020.1.0.0" Language="en-US" />
-    <DisplayName>CocoPlugin</DisplayName>
-    <Description xml:space="preserve" >This plugin enables the use of Coco/R inside Visual Studio 2015 - 2019</Description>
-    <MoreInfo>http://www.ssw.jku.at/coco/</MoreInfo>
-    <License>license.txt</License>
-    <Icon>Resources\Package.ico</Icon>
-    <Tags>Coco</Tags>
-  </Metadata>
-  <Installation>
-    <InstallationTarget Version="[14.0,17.0)" Id="Microsoft.VisualStudio.Community" />
-    <InstallationTarget Version="[14.0,17.0)" Id="Microsoft.VisualStudio.Pro" />
-    <InstallationTarget Version="[14.0,17.0)" Id="Microsoft.VisualStudio.Enterprise" />
-  </Installation>
-  <Dependencies>
-    <Dependency d:Source="Installed" Id="Microsoft.VisualStudio.Platform" DisplayName="Microsoft Visual Studio Shell Components" Version="[11.0,12.0)" />
-    <Dependency d:Source="Installed" Id="Microsoft.VisualStudio.ErrorListPkg" DisplayName="Microsoft Visual Studio Editor" Version="[14.0,15.0)" />
-  </Dependencies>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-    <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="File" Path="ItemTemplates" d:TargetPath="ItemTemplates\Code\Grammar.zip" />
-  </Assets>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.Net.Component.4.6.1.TargetingPack" Version="[15.0.26208.0,)" DisplayName=".NET Framework 4.6.1 targeting pack" />
-  </Prerequisites>
+    <Metadata>
+        <Identity Publisher="ssw.jku.at" Id="63c2b4b8-8a51-4fc4-b8ed-0b49e24146c3" Version="2020.1.0.0" Language="en-US" />
+        <DisplayName>CocoPlugin</DisplayName>
+        <Description xml:space="preserve" >This plugin enables the use of Coco/R inside Visual Studio 2015 - 2019</Description>
+        <MoreInfo>http://www.ssw.jku.at/coco/</MoreInfo>
+        <License>license.txt</License>
+        <Icon>Resources\Package.ico</Icon>
+        <Tags>Coco</Tags>
+    </Metadata>
+    <Installation>
+        <InstallationTarget Version="[14.0,17.0)" Id="Microsoft.VisualStudio.Community" />
+        <InstallationTarget Version="[14.0,17.0)" Id="Microsoft.VisualStudio.Pro" />
+        <InstallationTarget Version="[14.0,17.0)" Id="Microsoft.VisualStudio.Enterprise" />
+    </Installation>
+    <Dependencies>
+        <Dependency d:Source="Installed" Id="Microsoft.VisualStudio.Platform" DisplayName="Microsoft Visual Studio Shell Components" Version="[11.0,12.0)" />
+        <Dependency d:Source="Installed" Version="[16.0,17.0)" Id="Microsoft.VisualStudio.Platform.Editor" DisplayName="Microsoft Visual Studio Editor" />
+    </Dependencies>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+        <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="File" Path="ItemTemplates" d:TargetPath="ItemTemplates\Code\Grammar.zip" />
+    </Assets>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.Net.Component.4.7.2.TargetingPack" Version="[16.10.31205.252,17.0)" DisplayName=".NET Framework 4.7.2 targeting pack" />
+    </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
…fest.

Upgraded CocoPlugin project to .Net 4.7.2 to be able to build it on VS2019 on Win11.
Updated/changed/added project references in accordance with this.